### PR TITLE
simplify git push with tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ import './index.html';
 Updating version:
 
 * `npm version patch` - Bump version
-* `git push && git push --tags` - Push to remote
+* `git push --tags` - Push to remote
 
 Publishing package:
 


### PR DESCRIPTION
There is no need to run push twice, 'cause you can run it with tags flag first time