### PR TITLE
Update loaders.js

### DIFF
--- a/webpack/loaders.js
+++ b/webpack/loaders.js
@@ -31,8 +31,11 @@ if (DEBUG || TEST) {
   jsxLoader = [];
   if (!TEST) {
     jsxLoader.push('react-hot');
+    jsxLoader.push('babel-loader?optional[]=runtime&stage=0');
+  } else {
+    jsxLoader.push('babel-loader?optional[]=runtime&stage=0&plugins=rewire');
   }
-  jsxLoader.push('babel-loader?optional[]=runtime&stage=0&plugins=rewire');
+  }
   sassParams.push('sourceMap', 'sourceMapContents=true');
   sassLoader = [
     'style-loader',


### PR DESCRIPTION
Don't need babel-plugin-rewire on debug mode. It throws errors.
