### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ export default class Menu extends Component {
 }
 ```
 
-###Writing tests:
+### Writing tests:
 
 ```js
 // Filename: __tests__/Menu-test.jsx


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
